### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/lib/telegramNotifier.ts
+++ b/lib/telegramNotifier.ts
@@ -1,5 +1,12 @@
 import { ContactFormData } from './types';
 
+// Helper function to escape all MarkdownV2 special characters
+function escapeMarkdownV2(text: string): string {
+  // List of characters to escape in MarkdownV2
+  // See: https://core.telegram.org/bots/api#markdownv2-style
+  return text.replace(/([_*\[\]()~`>#+\-=|{}\.!\\])/g, '\\$1');
+}
+
 export async function sendTelegramNotification(formData: ContactFormData) {
   const botToken = process.env.TELEGRAM_BOT_TOKEN;
   const chatId = process.env.TELEGRAM_CHAT_ID;
@@ -10,10 +17,11 @@ export async function sendTelegramNotification(formData: ContactFormData) {
   }
 
   const { name, email, service, message } = formData;
-  const text = `📬 *New Contact Form Submission*\n*Name:* ${name}\n*Email:* ${email}\n*Service:* ${service}\n*Message:* ${message}`
-    .replace(/_/g, '\\_') // Escape underscores for Markdown
-    .replace(/-/g, '\\-') // Escape dashes
-    .replace(/\./g, '\\.'); // Escape dots
+  const safeName = escapeMarkdownV2(name);
+  const safeEmail = escapeMarkdownV2(email);
+  const safeService = escapeMarkdownV2(service);
+  const safeMessage = escapeMarkdownV2(message);
+  const text = `📬 *New Contact Form Submission*\n*Name:* ${safeName}\n*Email:* ${safeEmail}\n*Service:* ${safeService}\n*Message:* ${safeMessage}`;
 
   try {
     const response = await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {


### PR DESCRIPTION
Potential fix for [https://github.com/justbecauseph/justbecause-landing/security/code-scanning/3](https://github.com/justbecauseph/justbecause-landing/security/code-scanning/3)

To fix the problem, all MarkdownV2 meta-characters—including the backslash—must be escaped in the user-supplied input. The best way to do this is to write a helper function that escapes all special characters as per the [Telegram MarkdownV2 documentation](https://core.telegram.org/bots/api#markdownv2-style). This function should be applied to each user-supplied field before interpolation into the template string. The function should escape the following characters: `_`, `*`, `[`, `]`, `(`, `)`, `~`, '`', `>`, `#`, `+`, `-`, `=`, `|`, `{`, `}`, `.`, `!`, and `\` (backslash). The fix should be implemented in `lib/telegramNotifier.ts` by adding the helper function and using it to sanitize `name`, `email`, `service`, and `message` before constructing the `text` variable.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
